### PR TITLE
Add Initial Backend Options

### DIFF
--- a/app/code/community/SomethingDigital/BackToTop/Helper/Data.php
+++ b/app/code/community/SomethingDigital/BackToTop/Helper/Data.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Something Digital
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the 
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies 
+ * or substantial portions of the Software.
+ *
+ * @package     SomethingDigital_BackToTop
+ * @author      Brandyn Bold <brandynbold@gmail.com>
+ * @copyright   Copyright (c) 2015 Something Digital
+ * @license     https://opensource.org/licenses/MIT  The MIT License (MIT)
+ */
+
+class SomethingDigital_BackToTop_Helper_Data extends Mage_Core_Helper_Data
+{
+    /**
+     * Check if module is enabled or not
+     * 
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return Mage::getStoreConfigFlag('sd_backtotop/options/enabled');
+    }
+
+    /**
+     * Get The method of persistance
+     * 
+     * @return int
+     */
+    public function getPersistMethod()
+    {
+        return Mage::getStoreConfig('sd_backtotop/options/persist');
+    }
+
+    /**
+     * Get the speed in which the user is scrolled to the top
+     * 
+     * @return int
+     */
+    public function getScrollSpeed()
+    {
+        return Mage::getStoreConfig('sd_backtotop/options/scroll');
+    }
+
+    /**
+     * Get the text to display in the link
+     * 
+     * @return string
+     */
+    public function getText()
+    {
+        return Mage::getStoreConfig('sd_backtotop/design/frontendtext');
+    }
+}

--- a/app/code/community/SomethingDigital/BackToTop/Model/System/Config/Source/DropDown/Persist.php
+++ b/app/code/community/SomethingDigital/BackToTop/Model/System/Config/Source/DropDown/Persist.php
@@ -6,10 +6,10 @@
  * this software and associated documentation files (the "Software"), to deal in the
  * Software without restriction, including without limitation the rights to use, copy,
  * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
- * and to permit persons to whom the Software is furnished to do so, subject to the
+ * and to permit persons to whom the Software is furnished to do so, subject to the 
  * following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies
+ * The above copyright notice and this permission notice shall be included in all copies 
  * or substantial portions of the Software.
  *
  * @package     SomethingDigital_BackToTop
@@ -17,17 +17,20 @@
  * @copyright   Copyright (c) 2015 Something Digital
  * @license     https://opensource.org/licenses/MIT  The MIT License (MIT)
  */
-?>
 
-<?php if($this->helper('sd_backtotop')->isEnabled()): ?>
-
-  <a href="#" id="back-to-top" class="back-to-top">
-    <span class="back-to-top__up-arrow">
-      <svg viewBox="0 0 44 44" class="sd-icon glyph">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="<?php echo $this->getSkinUrl('images/svg/src.svg'); ?>#desc"></use>
-      </svg>
-    </span>
-    <?php echo $this->helper('sd_backtotop')->getText(); ?>
-  </a>
-
-<?php endif; ?>
+class SomethingDigital_BackToTop_Model_System_Config_Source_DropDown_Persist
+{
+  public function toOptionArray()
+  {
+    return array(
+      array(
+        'value' => 'persist',
+        'label' => 'Persist After Scrolling',
+      ),
+      array(
+        'value' => 'scroll',
+        'label' => 'Show While Scrolling Up',
+      ),
+    );
+  }
+}

--- a/app/code/community/SomethingDigital/BackToTop/etc/adminhtml.xml
+++ b/app/code/community/SomethingDigital/BackToTop/etc/adminhtml.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<config>
+    <acl>
+        <resources>
+            <admin>
+                <children>
+                    <system>
+                        <children>
+                            <config>
+                                <children>
+                                    <sd_backtotop translate="title" module="sd_backtotop">
+                                        <title>Back To Top</title>
+                                    </sd_backtotop>
+                                </children>
+                            </config>
+                        </children>
+                    </system>
+                </children>
+            </admin>
+        </resources>
+    </acl>
+</config>

--- a/app/code/community/SomethingDigital/BackToTop/etc/config.xml
+++ b/app/code/community/SomethingDigital/BackToTop/etc/config.xml
@@ -5,6 +5,18 @@
       <version>1.0.0</version>
     </SomethingDigital_BackToTop>
   </modules>
+  <global>
+    <helpers>
+      <sd_backtotop>
+        <class>SomethingDigital_BackToTop_Helper</class>
+      </sd_backtotop>
+    </helpers>
+    <models>
+        <sd_backtotop>
+            <class>SomethingDigital_BackToTop_Model</class>
+        </sd_backtotop>
+    </models>
+  </global>
   <frontend>
     <layout>
       <updates>
@@ -14,4 +26,16 @@
       </updates>
     </layout>
   </frontend>
+  <default>
+    <sd_backtotop>
+      <options>
+        <enabled>1</enabled>
+        <persist>1</persist>
+        <scroll>500</scroll>
+      </options>
+      <design>
+        <frontendtext>Back to Top</frontendtext>
+      </design>
+    </sd_backtotop>
+  </default>
 </config>

--- a/app/code/community/SomethingDigital/BackToTop/etc/system.xml
+++ b/app/code/community/SomethingDigital/BackToTop/etc/system.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <tabs>
+        <backtotop translate="label" module="sd_backtotop">
+            <label>Back to Top</label>
+            <sort_order>300</sort_order>
+        </backtotop>
+    </tabs>
+    <sections>
+        <sd_backtotop translate="label" module="sd_backtotop">
+            <label>Back to Top</label>
+            <tab>backtotop</tab>
+            <frontend_type>text</frontend_type>
+            <sort_order>1</sort_order>
+            <show_in_default>1</show_in_default>
+            <show_in_website>1</show_in_website>
+            <show_in_store>1</show_in_store>
+            <groups>
+                <options translate="label">
+                    <label>Options</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>2</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <enabled translate="label">
+                            <label>Enable</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enabled>
+                        <persist translate="label">
+                            <label>Show Link</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>sd_backtotop/system_config_source_dropdown_persist</source_model>
+                            <sort_order>2</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </persist>
+                        <scroll translate="label">
+                            <label>Scroll Speed</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>Speed (in milliseconds) to scroll to the top</comment>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </scroll>
+                    </fields>
+                </options>
+                <design translate="label">
+                    <label>Design</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>3</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <frontendtext translate="label">
+                            <label>Text</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>Text to be shown in the Back to Top Link</comment>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </frontendtext>
+                    </fields>
+                </design>
+            </groups>
+        </sd_backtotop>
+    </sections>
+</config>

--- a/app/design/frontend/base/default/layout/somethingdigital/backtotop/somethingdigital_backtotop.xml
+++ b/app/design/frontend/base/default/layout/somethingdigital/backtotop/somethingdigital_backtotop.xml
@@ -8,9 +8,21 @@
         </action>
     </reference>
     <reference name="before_body_end">
-        <block type="core/template" name="back.to.top.config" template="somethingdigital/backtotop/data/config.phtml" />
-        <block type="core/template" name="back.to.top.js" template="somethingdigital/backtotop/data/js.phtml" />
-        <block type="core/template" name="back.to.top" template="somethingdigital/backtotop/back-to-top.phtml" />
+        <block type="core/template" name="back.to.top.config">
+            <action method="setTemplate" ifconfig="sd_backtotop/options/enabled">
+               <template>somethingdigital/backtotop/data/config.phtml</template>
+            </action>
+        </block>
+        <block type="core/template" name="back.to.top.js">
+            <action method="setTemplate" ifconfig="sd_backtotop/options/enabled">
+               <template>somethingdigital/backtotop/data/js.phtml</template>
+            </action>
+        </block>
+        <block type="core/template" name="back.to.top">
+            <action method="setTemplate" ifconfig="sd_backtotop/options/enabled">
+               <template>somethingdigital/backtotop/back-to-top.phtml</template>
+            </action>
+        </block>
     </reference>
   </default>
 </layout>

--- a/app/design/frontend/base/default/layout/somethingdigital/backtotop/somethingdigital_backtotop.xml
+++ b/app/design/frontend/base/default/layout/somethingdigital/backtotop/somethingdigital_backtotop.xml
@@ -3,15 +3,13 @@
   <default>
     <reference name="head">
         <action method="addItem">
-          <type>skin_js</type>
-          <name>js/somethingdigital/back-to-top.js</name>
-        </action>
-        <action method="addItem">
           <type>skin_css</type>
           <name>css/somethingdigital/back-to-top.css</name>
         </action>
     </reference>
     <reference name="before_body_end">
+        <block type="core/template" name="back.to.top.config" template="somethingdigital/backtotop/data/config.phtml" />
+        <block type="core/template" name="back.to.top.js" template="somethingdigital/backtotop/data/js.phtml" />
         <block type="core/template" name="back.to.top" template="somethingdigital/backtotop/back-to-top.phtml" />
     </reference>
   </default>

--- a/app/design/frontend/base/default/template/somethingdigital/backtotop/back-to-top.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/backtotop/back-to-top.phtml
@@ -19,8 +19,6 @@
  */
 ?>
 
-<?php if($this->helper('sd_backtotop')->isEnabled()): ?>
-
   <a href="#" id="back-to-top" class="back-to-top">
     <span class="back-to-top__up-arrow">
       <svg viewBox="0 0 44 44" class="sd-icon glyph">
@@ -29,5 +27,3 @@
     </span>
     <?php echo $this->helper('sd_backtotop')->getText(); ?>
   </a>
-
-<?php endif; ?>

--- a/app/design/frontend/base/default/template/somethingdigital/backtotop/data/config.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/backtotop/data/config.phtml
@@ -19,10 +19,8 @@
  */
 ?>
 
-<?php if($this->helper('sd_backtotop')->isEnabled()): ?>
-  <script type="text/javascript">
-    var BackToTopConfig = {};
-    BackToTopConfig.speed = <?php echo $this->helper('sd_backtotop')->getScrollSpeed(); ?>;
-    BackToTopConfig.persist = "<?php echo $this->helper('sd_backtotop')->getPersistMethod(); ?>";
-  </script>
-<?php endif; ?>
+<script type="text/javascript">
+  var BackToTopConfig = {};
+  BackToTopConfig.speed = <?php echo $this->helper('sd_backtotop')->getScrollSpeed(); ?>;
+  BackToTopConfig.persist = "<?php echo $this->helper('sd_backtotop')->getPersistMethod(); ?>";
+</script>

--- a/app/design/frontend/base/default/template/somethingdigital/backtotop/data/config.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/backtotop/data/config.phtml
@@ -20,14 +20,9 @@
 ?>
 
 <?php if($this->helper('sd_backtotop')->isEnabled()): ?>
-
-  <a href="#" id="back-to-top" class="back-to-top">
-    <span class="back-to-top__up-arrow">
-      <svg viewBox="0 0 44 44" class="sd-icon glyph">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="<?php echo $this->getSkinUrl('images/svg/src.svg'); ?>#desc"></use>
-      </svg>
-    </span>
-    <?php echo $this->helper('sd_backtotop')->getText(); ?>
-  </a>
-
+  <script type="text/javascript">
+    var BackToTopConfig = {};
+    BackToTopConfig.speed = <?php echo $this->helper('sd_backtotop')->getScrollSpeed(); ?>;
+    BackToTopConfig.persist = "<?php echo $this->helper('sd_backtotop')->getPersistMethod(); ?>";
+  </script>
 <?php endif; ?>

--- a/app/design/frontend/base/default/template/somethingdigital/backtotop/data/js.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/backtotop/data/js.phtml
@@ -20,14 +20,5 @@
 ?>
 
 <?php if($this->helper('sd_backtotop')->isEnabled()): ?>
-
-  <a href="#" id="back-to-top" class="back-to-top">
-    <span class="back-to-top__up-arrow">
-      <svg viewBox="0 0 44 44" class="sd-icon glyph">
-        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="<?php echo $this->getSkinUrl('images/svg/src.svg'); ?>#desc"></use>
-      </svg>
-    </span>
-    <?php echo $this->helper('sd_backtotop')->getText(); ?>
-  </a>
-
+  <script type="text/javascript" src="<?php echo $this->getSkinUrl('js/somethingdigital/back-to-top.js') ?>"></script>
 <?php endif; ?>

--- a/app/design/frontend/base/default/template/somethingdigital/backtotop/data/js.phtml
+++ b/app/design/frontend/base/default/template/somethingdigital/backtotop/data/js.phtml
@@ -19,6 +19,4 @@
  */
 ?>
 
-<?php if($this->helper('sd_backtotop')->isEnabled()): ?>
-  <script type="text/javascript" src="<?php echo $this->getSkinUrl('js/somethingdigital/back-to-top.js') ?>"></script>
-<?php endif; ?>
+<script type="text/javascript" src="<?php echo $this->getSkinUrl('js/somethingdigital/back-to-top.js') ?>"></script>

--- a/skin/frontend/base/default/js/somethingdigital/back-to-top.js
+++ b/skin/frontend/base/default/js/somethingdigital/back-to-top.js
@@ -1,12 +1,18 @@
 (function($) {
   var BackToTop = {
     scrollAppears: 300,
-    scrollSpeed: 300,
+    scrollSpeed: BackToTopConfig.speed,
+    persistMethod: BackToTopConfig.persist,
     anchorSide: 'left',
 
     init: function() {
-      this.anchorDiv();
-      this.bindScrollEvent();
+      if(this.persistMethod === 'persist') {
+        this.bindPersistShow();
+      } else if(this.persistMethod === 'scroll') {
+        this.bindScrollShow();
+      } else {
+        return;
+      }
 
       $('#back-to-top').on('click', function(e) {
         e.preventDefault();
@@ -18,7 +24,7 @@
         scrollTop: 0
       }, this.scrollSpeed);
     },
-    bindScrollEvent: function() {
+    bindPersistShow: function() {
       $(window).scroll(function() {
         if ($(window).scrollTop() > 300) {
           $('#back-to-top').fadeIn();
@@ -27,9 +33,18 @@
         }
       });
     },
-    anchorDiv: function() {
-      $('#back-to-top').css({'left': '0'});
-    }
+    bindScrollShow: function() {
+      var lastScrollTop = 0;
+      $(window).scroll(function(e){
+         var st = $(this).scrollTop();
+         if (st > lastScrollTop){
+           $('#back-to-top').fadeOut();
+         } else {
+           $('#back-to-top').fadeIn();
+         }
+         lastScrollTop = st;
+      });
+    },
   }
   BackToTop.init();
 }(jQuery));

--- a/skin/frontend/base/default/js/somethingdigital/back-to-top.js
+++ b/skin/frontend/base/default/js/somethingdigital/back-to-top.js
@@ -25,12 +25,12 @@
     },
     bindPersistShow: function() {
       $(window).scroll(function() {
-        if ($(window).scrollTop() > 300) {
+        if ($(window).scrollTop() > this.scrollAppears) {
           $('#back-to-top').fadeIn();
         } else {
           $('#back-to-top').fadeOut();
         }
-      });
+      }.bind(this));
     },
     bindScrollShow: function() {
       var lastScrollTop = 0;

--- a/skin/frontend/base/default/js/somethingdigital/back-to-top.js
+++ b/skin/frontend/base/default/js/somethingdigital/back-to-top.js
@@ -3,7 +3,6 @@
     scrollAppears: 300,
     scrollSpeed: BackToTopConfig.speed,
     persistMethod: BackToTopConfig.persist,
-    anchorSide: 'left',
 
     init: function() {
       if(this.persistMethod === 'persist') {


### PR DESCRIPTION
Add the following options to the backend:
- Enabled: turn on/off back to top
- Persist Method: Choose whether to have the btt button show after scrolling 300px or
  only when scrolling up.
- Scroll Speed: Speed in which the page scrolls to the top
- Text: Text that is displayed for 'back to top'
